### PR TITLE
Get rid of PEP8 warnings

### DIFF
--- a/more/forwarded/forwarded.py
+++ b/more/forwarded/forwarded.py
@@ -80,7 +80,7 @@ def parse(header):
         item = {}
         element = element.strip()
         if not element:
-          continue
+            continue
         for pair in element.split(';'):
             token, equals, value = pair.partition('=')
             if equals != '=':
@@ -103,4 +103,3 @@ def parse(header):
             item[token] = value
         result.append(item)
     return result
-


### PR DESCRIPTION
The extra line I can excuse, but two spaces? Heathen! :wink:
